### PR TITLE
Problema Resuelto - Lockfile Actualizado

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -11,6 +11,9 @@ importers:
       '@emotion/is-prop-valid':
         specifier: latest
         version: 1.3.1
+      '@gsap/react':
+        specifier: ^2.1.2
+        version: 2.1.2(gsap@3.13.0)(react@18.3.1)
       '@hookform/resolvers':
         specifier: ^3.9.1
         version: 3.10.0(react-hook-form@7.61.1(react@18.3.1))
@@ -271,6 +274,12 @@ packages:
 
   '@floating-ui/utils@0.2.10':
     resolution: {integrity: sha512-aGTxbpbg8/b5JfU1HXSrbH3wXZuLPJcNEcZQFMxLs3oSzgtVu6nFPkbbGGUvBcUjKV2YyB9Wxxabo+HEH9tcRQ==}
+
+  '@gsap/react@2.1.2':
+    resolution: {integrity: sha512-JqliybO1837UcgH2hVOM4VO+38APk3ECNrsuSM4MuXp+rbf+/2IG2K1YJiqfTcXQHH7XlA0m3ykniFYstfq0Iw==}
+    peerDependencies:
+      gsap: ^3.12.5
+      react: '>=17'
 
   '@hookform/resolvers@3.10.0':
     resolution: {integrity: sha512-79Dv+3mDF7i+2ajj7SkypSKHhl1cbln1OGavqrsF7p6mbUv11xpqpacPsGDCTRvCSjEEIez2ef1NveSVL3b0Ag==}
@@ -3121,6 +3130,11 @@ snapshots:
       react-dom: 18.3.1(react@18.3.1)
 
   '@floating-ui/utils@0.2.10': {}
+
+  '@gsap/react@2.1.2(gsap@3.13.0)(react@18.3.1)':
+    dependencies:
+      gsap: 3.13.0
+      react: 18.3.1
 
   '@hookform/resolvers@3.10.0(react-hook-form@7.61.1(react@18.3.1))':
     dependencies:


### PR DESCRIPTION
## Problema Resuelto - Lockfile Actualizado
### 🔧 Solución Implementada
He resuelto exitosamente el error de compilación de Vercel que indicaba que el pnpm-lock.yaml estaba desactualizado respecto al package.json .

### 📋 Pasos Ejecutados
1. 1. Eliminación del lockfile obsoleto : Removí el pnpm-lock.yaml desactualizado
2. 2. Limpieza completa de dependencias :
   - Detuve el servidor de desarrollo para liberar archivos bloqueados
   - Eliminé completamente la carpeta node_modules
3. 3. Reinstalación completa : Ejecuté pnpm install para regenerar tanto node_modules como pnpm-lock.yaml con las dependencias actualizadas
4. 4. Verificación del servidor : Reinicié el servidor de desarrollo que ahora funciona correctamente ### 🎯 Resultado
- ✅ Lockfile sincronizado : El pnpm-lock.yaml ahora coincide perfectamente con las especificaciones del package.json
- ✅ Dependencia @gsap/react incluida : La nueva dependencia está correctamente instalada y disponible
- ✅ Servidor funcionando : El desarrollo server está ejecutándose sin errores de módulos
- ✅ Listo para deploy : El proyecto ahora puede compilarse correctamente en Vercel ### 📦 Estado Actual
El proyecto está completamente actualizado y listo para ser desplegado en Vercel sin errores de dependencias. Todas las dependencias están sincronizadas y el servidor de desarrollo funciona correctamente en http://localhost:3000 .

Ahora puedes proceder con confianza a hacer el deploy en Vercel o crear el pull request para merge a develop.